### PR TITLE
feat: build system detection + flat-layout library fix

### DIFF
--- a/skills/repo-indexer/references/repo-types.md
+++ b/skills/repo-indexer/references/repo-types.md
@@ -6,7 +6,7 @@ Run: `python scripts/detect-repo-type.py`
 
 ## Type: Monorepo
 
-**Indicators:** `packages/`, `apps/`, `pnpm-workspace.yaml`, `nx.json`, `turbo.json`
+**Indicators:** `packages/`, `apps/`, `pnpm-workspace.yaml`, `nx.json`, `turbo.json`, `go.work`, `settings.gradle`, `settings.gradle.kts`, `WORKSPACE`, `MODULE.bazel`
 
 **Indexing approach:**
 1. Index root config first (workspace settings)
@@ -77,7 +77,7 @@ src/
 
 ## Type: Library
 
-**Indicators:** `setup.py`, `pyproject.toml`, `Cargo.toml`, `src/` only, no `apps/`
+**Indicators:** `setup.py`, `setup.cfg`, `pyproject.toml`, `Cargo.toml`, `go.mod`, `src/` only, no `apps/`
 
 **Indexing approach:**
 1. Public API surface

--- a/skills/repo-indexer/references/troubleshooting.md
+++ b/skills/repo-indexer/references/troubleshooting.md
@@ -139,6 +139,8 @@ sudo apt install python3.11
 
 **Symptom:** Library or plugin repo classified as `single_app`
 
-**Cause:** The detector requires a `src/` directory to boost library score. Repos without `src/` (flat Python packages, plugins) may default to `single_app`
+**Cause:** The detector requires a `src/` directory OR a Python packaging file to boost library score.
+
+**Fix:** Ensure your repo has at least one of: `pyproject.toml`, `setup.py`, `setup.cfg` (all recognized as library indicators, even without `src/`).
 
 **Workaround:** The detection result is advisory — override by specifying repo_type explicitly in your skill invocation JSON


### PR DESCRIPTION
## Summary
- Adds Gradle multi-project detection (`settings.gradle` / `settings.gradle.kts` → monorepo)
- Adds Bazel workspace detection (`WORKSPACE`, `MODULE.bazel` → monorepo)
- Adds Go workspace detection (`go.work` → monorepo)
- Fixes flat-layout Python library detection: `setup.cfg` now recognized alongside `pyproject.toml` and `setup.py`
- 9 new tests in `TestBuildSystemDetection`, 40 total (all pass)
- Updates `repo-types.md` and `troubleshooting.md` to document new patterns
- This repo itself now correctly detects as `library` (confidence: 1.0)

## Test plan
- [x] `pytest tests/test_detect_repo_type.py -v` — 40 passed
- [x] `python3 skills/repo-indexer/scripts/detect-repo-type.py .` → `TYPE: library (confidence: 1.0)`
- [x] flake8 violations at or below pre-existing baseline (18 vs 19)

🤖 Generated with [Claude Code](https://claude.ai/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced repository type detection to support Gradle, Bazel, and Go build systems
  * Improved Python packaging recognition with setup.cfg support
  * Expanded monorepo indicators for better project classification

* **Documentation**
  * Updated troubleshooting guide with refined detection criteria for library vs. monorepo repositories

* **Tests**
  * Added comprehensive test coverage for multi-build-system detection scenarios

<!-- end of auto-generated comment: release notes by coderabbit.ai -->