### PR TITLE
feat: add repo-type-specific CLAUDE.md template variants

### DIFF
--- a/skills/repo-indexer/SKILL.md
+++ b/skills/repo-indexer/SKILL.md
@@ -75,6 +75,14 @@ Before generating files, present the proposed `.claude/` structure to the user f
 
 Full analysis using format in `references/templates.md` → "Indexing Output Format". Include `### SEARCH KEYWORDS` for retrieval.
 
+**Select CLAUDE.md template by repo type:**
+
+Use the type-specific variant from `references/templates.md`:
+- **Monorepo** → "CLAUDE.md — Monorepo variant" (packages list, workspace commands)
+- **Library** → "CLAUDE.md — Library variant" (public API section, publish commands)
+- **Microservices** → "CLAUDE.md — Microservices variant" (services table, compose commands)
+- **Single App** → base "CLAUDE.md" template
+
 **Create files:**
 
 ```

--- a/skills/repo-indexer/references/templates.md
+++ b/skills/repo-indexer/references/templates.md
@@ -2,7 +2,10 @@
 
 ## Contents
 
-- [CLAUDE.md](#claudemd-500-tokens)
+- [CLAUDE.md (base)](#claudemd-500-tokens)
+- [CLAUDE.md — Monorepo](#claudemd-monorepo-variant)
+- [CLAUDE.md — Library](#claudemd-library-variant)
+- [CLAUDE.md — Microservices](#claudemd-microservices-variant)
 - [architecture.md](#architecturemd)
 - [conventions.md](#conventionsmd)
 - [glossary.md](#glossarymd)
@@ -26,6 +29,119 @@
 
 # Run
 {run_cmd}
+
+# Test
+{test_cmd}
+
+# Build
+{build_cmd}
+```
+
+## Context Loading
+1. Claude memory has repo overview
+2. Search past chats: "{repo-name} architecture"
+3. If needed: `cat .claude/memory/{file}.md`
+
+<!-- USER: Add notes below -->
+````
+
+---
+
+## CLAUDE.md — Monorepo variant
+
+````markdown
+# {repo-name}
+{One sentence: purpose, users, core value}
+
+## Stack
+{lang} {version}, {framework}, {key-dep-1}, {key-dep-2}
+
+## Packages
+- `packages/{name}` - {description}
+- `apps/{name}` - {description}
+
+## Commands
+```bash
+# Install all packages
+{install_cmd}
+
+# Run workspace command
+{workspace_cmd} {package} {command}
+
+# Test all
+{test_cmd}
+
+# Build
+{build_cmd}
+```
+
+## Context Loading
+1. Claude memory has repo overview
+2. Search past chats: "{repo-name} architecture"
+3. If needed: `cat .claude/memory/{file}.md`
+
+<!-- USER: Add notes below -->
+````
+
+---
+
+## CLAUDE.md — Library variant
+
+````markdown
+# {repo-name}
+{One sentence: what the library does, target users}
+
+## Stack
+{lang} {version}, {framework}, {key-dep-1}
+
+## Public API
+- `{module}.{function}()` - {description}
+- `{module}.{Class}` - {description}
+
+## Commands
+```bash
+# Install
+{install_cmd}
+
+# Test
+{test_cmd}
+
+# Build / publish
+{build_cmd}
+{publish_cmd}
+```
+
+## Context Loading
+1. Claude memory has repo overview
+2. Search past chats: "{repo-name} architecture"
+3. If needed: `cat .claude/memory/{file}.md`
+
+<!-- USER: Add notes below -->
+````
+
+---
+
+## CLAUDE.md — Microservices variant
+
+````markdown
+# {repo-name}
+{One sentence: system purpose and users}
+
+## Stack
+{lang} {version}, {framework}, {db}, {message-broker}
+
+## Services
+| Service | Purpose | Port |
+|---------|---------|------|
+| `{service-name}` | {description} | {port} |
+
+## Commands
+```bash
+# Start all services
+docker compose up
+
+# Start single service
+docker compose up {service}
 
 # Test
 {test_cmd}


### PR DESCRIPTION
## Summary
- Adds 3 type-specific CLAUDE.md template variants to `references/templates.md`:
  - **Monorepo**: packages list + workspace commands (e.g. `pnpm -F {pkg} {cmd}`)
  - **Library**: public API section + build/publish commands
  - **Microservices**: services table (name, purpose, port) + docker compose commands
- Updates `templates.md` table of contents
- Updates `SKILL.md` Phase 4 to route to the correct variant based on `detect-repo-type.py` output (single_app falls back to the base template)

## Test plan
- [x] No script changes — doc-only update, no automated tests needed
- [x] `pytest tests/ -v` — all tests still pass (no regressions)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added new CLAUDE.md template variants tailored for different repository types: Monorepo, Library, Microservices, and Single App.
  * Introduced guidance to help select the appropriate template variant based on project structure.
  * Each template variant includes dedicated sections for Stack, Packages/Services, Commands, and Context Loading.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->