### PR TITLE
chore: release v0.0.2

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -6,7 +6,7 @@
   "plugins": [
     {
       "name": "repo-indexer",
-      "version": "0.0.1",
+      "version": "0.0.2",
       "source": "./",
       "description": "Indexes codebases for persistent Claude context with tiered memory architecture"
     }

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "repo-indexer",
   "description": "Indexes and documents codebases for persistent Claude context with minimal token overhead. Creates tiered memory (native memory + CLAUDE.md + on-demand files + conversation history) so Claude remembers your projects across sessions.",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "author": {
     "name": "JayaShankar Mangina",
     "url": "https://github.com/jyshnkr"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,25 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ---
 
+## [0.0.2] - 2026-02-21
+
+### Added
+- Gradle multi-project detection (`settings.gradle`, `settings.gradle.kts` → monorepo)
+- Bazel workspace detection (`WORKSPACE`, `MODULE.bazel`, `BUILD` files → monorepo)
+- Go workspace detection (`go.work` → monorepo)
+- `setup.cfg` as library indicator (flat-layout Python packages now detected correctly)
+- Shallow clone handling in `git-sync.sh` (`git fetch --unshallow` with graceful fallback)
+- Code/prose token estimation modes in `estimate-tokens.py` (`mode` parameter, `_guess_content_mode()`)
+- Repo-type-specific CLAUDE.md templates: monorepo, library, microservices variants
+- `TestBuildSystemDetection` test class (9 new tests)
+
+### Fixed
+- Flat-layout Python library detection: `setup.cfg` now recognized alongside `pyproject.toml`/`setup.py`
+- `git-sync.sh` missing-remote error now shows available remotes and `git remote add origin` fix hint
+- `git-sync.sh` fetch failure error now includes remote URL and raw error output
+
+---
+
 ## [0.0.1] - 2026-02-20
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 **Index any codebase for persistent Claude context — minimal token overhead between sessions (~500 tokens for CLAUDE.md boot).**
 
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](LICENSE)
-[![Version](https://img.shields.io/badge/version-0.0.1-blue.svg)](.claude-plugin/plugin.json)
+[![Version](https://img.shields.io/badge/version-0.0.2-blue.svg)](.claude-plugin/plugin.json)
 [![Claude Code Plugin](https://img.shields.io/badge/Claude%20Code-Plugin-orange.svg)](https://claude.ai/plugins)
 
 ---

--- a/skills/repo-indexer/SKILL.md
+++ b/skills/repo-indexer/SKILL.md
@@ -5,7 +5,7 @@ allowed-tools: Bash, Read, Write, Glob, Grep
 argument-hint: [path]
 license: MIT
 metadata:
-  version: 0.0.1
+  version: 0.0.2
   author: JayaShankar Mangina
 ---
 


### PR DESCRIPTION
## Summary
Version bump to **0.0.2** — includes all improvements from phases 1–4.

- `plugin.json`, `marketplace.json`, `SKILL.md`: `0.0.1` → `0.0.2`
- `README.md`: version badge updated
- `CHANGELOG.md`: `[0.0.2]` section added

## What's in 0.0.2

### Added
- Gradle multi-project detection (`settings.gradle`, `settings.gradle.kts` → monorepo)
- Bazel workspace detection (`WORKSPACE`, `MODULE.bazel` → monorepo)
- Go workspace detection (`go.work` → monorepo)
- `setup.cfg` as library indicator (flat-layout Python packages now detected correctly)
- Shallow clone handling in `git-sync.sh`
- Code/prose token estimation modes (`mode` parameter + `_guess_content_mode()`)
- Repo-type-specific CLAUDE.md templates (monorepo, library, microservices)

### Fixed
- Flat-layout Python library detection (`setup.cfg` now recognized)
- `git-sync.sh` missing-remote error now shows available remotes + fix hint
- `git-sync.sh` fetch failure error now includes remote URL and raw error output

## Test plan
- [x] `pytest tests/ -v` — **98 passed**
- [x] `python3 skills/repo-indexer/scripts/detect-repo-type.py .` → `TYPE: library (confidence: 1.0)`
- [x] `shellcheck skills/repo-indexer/scripts/git-sync.sh` — clean
- [x] CI version-sync check will pass (plugin.json == marketplace.json == 0.0.2)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added workspace detectors for Gradle, Bazel, and Go environments
  * Introduced setup.cfg as a supported library indicator
  * Added multiple new estimate-tokens processing modes
  * Added CLAUDE.md template generation support

* **Bug Fixes**
  * Resolved Python flat-layout detection issues
  * Improved git-sync.sh error messaging and output handling

* **Chores**
  * Version updated to 0.0.2

<!-- end of auto-generated comment: release notes by coderabbit.ai -->