### PR TITLE
chore: update CHANGELOG entry with v0.0.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,13 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ---
 
-## [Unreleased]
+## [0.0.3] - 2026-02-22
+
+### Fixed
+- Double-counting fix in docker-compose parsing (services defined multiple times)
+- Credential redaction fix for token-only URLs (e.g., `https://x-access-token@github.com/`)
+- Anchor link corrections in templates.md (broken internal links)
+- script_path constant extraction in tests (DRY improvement)
 
 ---
 


### PR DESCRIPTION
Changes:
- Updated CHANGELOG entry with v0.0.3

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Version 0.0.3 (2026-02-22)

* **Bug Fixes**
  * Fixed double-counting issue in docker-compose parsing when services are defined multiple times
  * Fixed credential redaction for token-only authentication URLs
* **Documentation**
  * Corrected broken internal links in templates documentation

<!-- end of auto-generated comment: release notes by coderabbit.ai -->